### PR TITLE
feat: .cmdb config directory

### DIFF
--- a/cmdb/views/cmdbmigration/setup.ftl
+++ b/cmdb/views/cmdbmigration/setup.ftl
@@ -165,7 +165,7 @@
                 [#local addHeader = true]
 
                 [#-- Capture the results of the migration --]
-                [#local result += {"Log" : result.Log + logSeparator("Capture results") } ]
+                [#local result += {"Log" : result.Log + logSeparator("Record results") } ]
 
                 [#-- Clean up any legacy .cmdb files - should only be one --]
                 [#local markerFiles = listFilesInDirectory(cmdb.CMDBPath, r"\.cmdb", {"IgnoreDotFiles" : false}) ]

--- a/cmdb/views/cmdbmigration/setup.ftl
+++ b/cmdb/views/cmdbmigration/setup.ftl
@@ -220,7 +220,7 @@
                     writeFile(
                         result,
                         formatAbsolutePath(cmdbMigrationsLogPath, migrationLogFilename),
-                        getJSON((getProgressLog(result) + ["#", "#"])?join('\n')),
+                        (getProgressLog(result) + ["#", "#"])?join('\n'),
                         "Create",
                         "migration log",
                         dryrun,
@@ -1483,7 +1483,14 @@ Make Directory
     [#local result = setProgressOK(progress) ]
 
     [#-- Nothing to do if it already exists --]
-    [#if findDirectoryMatches(dir, {"StopAfterFirstMatch" : true})?has_content ]
+    [#if findDirectories(
+            dir?keep_before_last('/'),
+            dir?keep_after_last('/'),
+            {
+                "IgnoreDotDirectories" : false,
+                "StopAfterFirstMatch" : true
+            }
+        )?has_content ]
         [#return result]
     [/#if]
 


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description
Convert the .cmdb marker file to a config directory and move the contents of the marker file into a `config.json` file.

Also capture the results of migrations in the `.cmdb` directory for reference. If migrations are rerun, the results will be appended to the existing log file.

## Motivation and Context
Capture a record of repo migrations

## How Has This Been Tested?
Local repo migrations

### Prerequisite PRs:
- https://github.com/hamlet-io/executor-bash/pull/235
- https://github.com/hamlet-io/executor-bash/pull/230

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

